### PR TITLE
Implemented cmake configuration and Fixed bug on release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,4 +2,11 @@ cmake_minimum_required(VERSION 3.15)
 
 project(assertutils)
 
+option(ASSERTUTILS_RELEASE "Less logging info and non verbosity" OFF)
+configure_file(
+	"${PROJECT_SOURCE_DIR}/include/assertutils/config/config.h.in"
+	"${PROJECT_SOURCE_DIR}/include/assertutils/config/config.h"
+)
+
 add_subdirectory(src)
+

--- a/include/assertutils/config/config.h
+++ b/include/assertutils/config/config.h
@@ -1,5 +1,7 @@
 #ifndef __CONFIG__H__
 #define __CONFIG__H__
 
+#define ASSERTUTILS_RELEASE
+
 #endif
 

--- a/include/assertutils/config/config.h.in
+++ b/include/assertutils/config/config.h.in
@@ -1,5 +1,7 @@
 #ifndef __CONFIG__H__
 #define __CONFIG__H__
 
+#cmakedefine __ASSERTUTILS_RELEASE__
+
 #endif
 

--- a/include/assertutils/config/config.h.in
+++ b/include/assertutils/config/config.h.in
@@ -1,7 +1,7 @@
 #ifndef __CONFIG__H__
 #define __CONFIG__H__
 
-#cmakedefine __ASSERTUTILS_RELEASE__
+#cmakedefine ASSERTUTILS_RELEASE
 
 #endif
 

--- a/include/assertutils/error.h
+++ b/include/assertutils/error.h
@@ -13,7 +13,7 @@ void log_status(const char* msg, const char* fn, const char* file, int line);
 void log_okf(const char* fn, const char* file, int line, const char* msg, ...);
 void log_statusf(const char* fn, const char* file, int line, const char* msg, ...);
 
-#ifndef __ASSERTUTILS_RELEASE__
+#ifndef ASSERTUTILS_RELEASE
 void log_err(const char* msg, const char* fn, const char* file, int line);
 void log_warn(const char* msg, const char* fn, const char* file, int line);
 
@@ -21,7 +21,7 @@ void log_errf(const char* fn, const char* file, int line, const char* msg, ...);
 void log_warnf(const char* fn, const char* file, int line, const char* msg, ...);
 #endif
 
-#ifndef __ASSERTUTILS_RELEASE__
+#ifndef ASSERTUTILS_RELEASE
 
 #define ERR(msg) log_err(msg, __func__, __FILE__, __LINE__)
 #define WARN(msg) log_warn(msg, __func__, __FILE__, __LINE__)
@@ -43,11 +43,11 @@ void log_warnf(const char* fn, const char* file, int line, const char* msg, ...)
 #define NICE(msg) log_ok(msg, __func__, "?", 0)
 #define INFO(msg) log_status(msg, __func__, "?", 0)
 
-#define NICEF(msg) log_okf(__func__, "?", 0, msg, __VA_ARGS__)
-#define INFOF(msg) log_statusf(__func__, "?", 0, msg, __VA_ARGS__)
+#define NICEF(msg, ...) log_okf(__func__, "?", 0, msg, __VA_ARGS__)
+#define INFOF(msg, ...) log_statusf(__func__, "?", 0, msg, __VA_ARGS__)
 
-#define ERRF(fmt) do{}while(0)
-#define WARNF(fmt) do{}while(0)
+#define ERRF(fmt, ...) do{}while(0)
+#define WARNF(fmt, ...) do{}while(0)
 
 #endif
 

--- a/include/assertutils/error.h
+++ b/include/assertutils/error.h
@@ -13,7 +13,7 @@ void log_status(const char* msg, const char* fn, const char* file, int line);
 void log_okf(const char* fn, const char* file, int line, const char* msg, ...);
 void log_statusf(const char* fn, const char* file, int line, const char* msg, ...);
 
-#ifndef __RELEASE__
+#ifndef __ASSERTUTILS_RELEASE__
 void log_err(const char* msg, const char* fn, const char* file, int line);
 void log_warn(const char* msg, const char* fn, const char* file, int line);
 
@@ -21,7 +21,7 @@ void log_errf(const char* fn, const char* file, int line, const char* msg, ...);
 void log_warnf(const char* fn, const char* file, int line, const char* msg, ...);
 #endif
 
-#ifndef __RELEASE__
+#ifndef __ASSERTUTILS_RELEASE__
 
 #define ERR(msg) log_err(msg, __func__, __FILE__, __LINE__)
 #define WARN(msg) log_warn(msg, __func__, __FILE__, __LINE__)

--- a/src/assertutils/error.c
+++ b/src/assertutils/error.c
@@ -37,7 +37,7 @@ void log_statusf(const char* fn, const char* file, int line, const char* msg, ..
 
 }
 
-#ifndef __ASSERTUTILS_RELEASE__
+#ifndef ASSERTUTILS_RELEASE
 void log_err(const char* msg, const char* fn, const char* file, int line) {
 	fprintf(stderr, "\033[31;1mFAIL\t\033[0m\033[1m%.10s\t:%d [\033[32;1m%s\033[0m\033[1m] => \033[31;1m'%s'\033[0m\n", file, line, fn, msg);
 }

--- a/src/assertutils/error.c
+++ b/src/assertutils/error.c
@@ -37,7 +37,7 @@ void log_statusf(const char* fn, const char* file, int line, const char* msg, ..
 
 }
 
-#ifndef __RELEASE__
+#ifndef __ASSERTUTILS_RELEASE__
 void log_err(const char* msg, const char* fn, const char* file, int line) {
 	fprintf(stderr, "\033[31;1mFAIL\t\033[0m\033[1m%.10s\t:%d [\033[32;1m%s\033[0m\033[1m] => \033[31;1m'%s'\033[0m\n", file, line, fn, msg);
 }


### PR DESCRIPTION
added option based `configure_file` to CMakeLists.txt

Fixed wrong macro definition (missing `...` on arguments list (WARNF/ERRF/NICEF/INFOF))